### PR TITLE
Close (#170): fixed padding on auth page header, gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.*
 
 # testing
 src/tests/coverage/
+
+#IDE
+.idea

--- a/src/components/header-with-back-arrow/HeaderWithBackArrow.styles.jsx
+++ b/src/components/header-with-back-arrow/HeaderWithBackArrow.styles.jsx
@@ -1,8 +1,8 @@
-import { StyleSheet } from 'react-native'
+import { Platform, StyleSheet } from 'react-native'
 
 export const styles = StyleSheet.create({
   headerContainer: {
-    paddingTop: 50,
+    paddingTop: Platform.OS === 'android' ? 50 : 20,
     display: 'flex',
     alignItems: 'center',
     flexDirection: 'row',

--- a/src/components/header-with-back-arrow/HeaderWithBackArrow.styles.jsx
+++ b/src/components/header-with-back-arrow/HeaderWithBackArrow.styles.jsx
@@ -2,6 +2,7 @@ import { StyleSheet } from 'react-native'
 
 export const styles = StyleSheet.create({
   headerContainer: {
+    paddingTop: 50,
     display: 'flex',
     alignItems: 'center',
     flexDirection: 'row',

--- a/src/components/header-with-back-arrow/index.js
+++ b/src/components/header-with-back-arrow/index.js
@@ -1,4 +1,4 @@
-import { View, Pressable } from 'react-native'
+import { View, Pressable, SafeAreaView } from 'react-native'
 import { AntDesign } from '@expo/vector-icons'
 import { Link } from 'expo-router'
 
@@ -16,10 +16,12 @@ const HeaderWithBackArrow = ({ route, text, onPress }) => {
     </Link>
   )
   return (
-    <View style={styles.headerContainer}>
-      {interactiveArrow}
-      <PaperText variant='headlineSmall'>{text}</PaperText>
-    </View>
+    <SafeAreaView>
+      <View style={styles.headerContainer}>
+        {interactiveArrow}
+        <PaperText variant='headlineSmall'>{text}</PaperText>
+      </View>
+    </SafeAreaView>
   )
 }
 


### PR DESCRIPTION
1. fixed padding on auth page header

![new1](https://github.com/user-attachments/assets/1baeaf9e-91bc-4e91-b9f2-d089c973d563)
![new2](https://github.com/user-attachments/assets/32d36202-332f-4086-987c-b3a3e04eaff5)

2. updated gitignore file, excluded webstorm ide file .idea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved header spacing by adjusting top padding based on the device platform for a more consistent appearance.
- **New Features**
  - Enhanced the header component with safe area support to better accommodate device notches and screen edges.
- **Chores**
  - Updated project settings to ignore IDE-specific files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->